### PR TITLE
Add support for data-t for column filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,23 @@ By default, the Fixtable will automatically filter itself as the user types into
 
 To disable real-time filtering, simply set the `realtimeFiltering` property to `false`. The Fixtable will automatically show Apply and Clear buttons that apply or clear the entered filters, respectively.
 
+#### Finding your filter from an automated test
+
+For ease of identifying a particular filter text box from within your automated tests, you can specify a data-t to be associated with the filter. Just specify a `dataT` property in your column definition. 
+
+```javascript
+[
+  {
+    key: 'name',
+    header: 'Name',
+    filter: {
+      type: 'search',
+      dataT: 'name-search-filter'
+    }
+  }
+]
+```
+
 #### Filter Placeholder Text
 
 You can specify placeholder text for search- and select-type filters by setting the value of the `placeholder` property within the `filter` object of the column definition.

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -39,7 +39,7 @@
                                         {{#if column.filter.component}}
                                             {{component column.filter.component columnDef=column filter=(mut (get filters column.key))}}
                                         {{else}}
-                                            <div class='input-group'>
+                                            <div class='input-group' data-t="{{column.filter.dataT}}">
                                                 {{#if (equals column.filter.type 'select')}}
                                                     <select class="form-control" onchange={{action (mut (get filters column.key)) value="target.value"}}>
                                                         <option value="">{{column.filter.placeholder}}</option>


### PR DESCRIPTION
This being my first PR for fixtable-ember (and github in general!) I thought I'd keep it simple this time around. I still think the simple data-t for filters is a significant step up, since there's no way to get access to those elements otherwise.